### PR TITLE
Fixed a bug in munge_sumstats.py and removed deprecation warnings with new version of pandas

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+10.4.24 v2.0.2: created a dockerfile so that the pybedtools package could locate bedtools for the make_annot.py script
+09.4.24 v2.0.2: updated a bug where readlines was returning a bytes object instead of a string that broke the list comprehension
 30.01.23 v2.0.1; update a bug introduced in "Fix globbing bug in splitp #221" that broke some flows
 11.10.22 v2.0.0; port to Python 3 and update to newer versions of pandas, numpy, and more
 02.01.20 Fix KeyError in allele_merge

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# LDSC (LD SCore) `v2.0.1`
+# LDSC (LD SCore) `v2.0.2`
 
 `ldsc` is a command line tool for estimating heritability and genetic correlation from GWAS summary statistics. `ldsc` also computes LD Scores.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,50 @@
 
 ## Getting Started
 
+There are several ways to install ldsc (v2.0.2). Docker and Pip are preferred but the user can also install from the github repository. Each of these ways are explained below:
 
+### Docker/Singularity
 
+ldsc is available as an image on docker and has been built for amd64 and arm64. This image can be pulled using the following command:
+
+```
+docker pull jtb114/ldsc-test
+```
+
+The working directory of this image is "app". There is a subdirectory called "ldsc" that has all the scripts used by ldsc such as "ldsc.py", "munge_sumstats.py", and "make_annot.py". Users can then run this image in interactive mode using the following command:
+
+```
+docker run -it jtb114/ldsc-test
+```
+
+Sometimes in HPC environments, other containerization software is preferred to docker. One option is Singularity. Singularity is able to pull images from Dockerhub so the following command will pull the ldsc image and build a singularity image:
+
+```
+singularity pull docker://jtb114/ldsc-test
+```
+
+This command will create a file called ldsc-test-latest.sif in the directory in which the command is run. Users can then run the singularity image using the following command:
+
+```
+singularity shell ldsc-test-latest.sif
+```
+
+This will open the container in an interactive mode. Users can find the scripts for ldsc in the root directory but running a command such as:
+
+```
+ls /app/ldsc/
+```
+
+### Pip:
+ldsc is also on PYPI and can be installed by Pip using the following command (It is preferable that the program be installed into a virtual environment created using venv or conda):
+
+```
+pip install ldsc
+```
+
+*warning:* The "make_annot.py" script requires that bedtools be installed. There have been issues when running ldsc on an HPC environment when bedtools has not been detect even when loaded/installed. If this error occurs, it is required to use the docker image to run ldsc.
+
+### Github:
 In order to download `ldsc`, you should clone this repository via the commands
 ```  
 git clone https://github.com/bulik/ldsc.git
@@ -29,6 +71,8 @@ Once the above has completed, you can run:
 to print a list of all command-line options. If these commands fail with an error, then something as gone wrong during the installation process. 
 
 Short tutorials describing the four basic functions of `ldsc` (estimating LD Scores, h2 and partitioned h2, genetic correlation, the LD Score regression intercept) can be found in the wiki. If you would like to run the tests, please see the wiki.
+
+*warning:* The "make_annot.py" script requires that bedtools be installed. There have been issues when running ldsc on an HPC environment when bedtools has not been detect even when loaded/installed. If this error occurs, it is required to use the docker image to run ldsc.
 
 ## Updating LDSC
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,26 +1,14 @@
 # syntax=docker/dockerfile:1
 
-FROM ubuntu:22.04
+FROM debian:bullseye-slim
 
 WORKDIR /app
 
 RUN  apt-get update \
-  && apt-get install -y wget python3.10 bedtools python3-pip \
-  && rm -rf /var/lib/apt/lists/* \
-  && pip install --upgrade pip
+  && apt install -y bedtools python3-pip \
+  && rm -rf /var/lib/apt/lists/* 
 
-# creating a folder for ldsc
-RUN mkdir ldsc
+COPY . /app/ldsc/
 
-COPY make_annot.py /app/ldsc/
-COPY munge_sumstats.py /app/ldsc/
-COPY ldsc.py /app/ldsc/
-COPY ./ldscore/ /app/ldsc/ldscore/
-
-# install all of the python dependencies
-COPY requirements.txt /app/
-
-RUN pip install -r requirements.txt
-
-
-
+RUN cd ldsc/ \
+  && pip install .

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM ubuntu:22.04
+
+WORKDIR /app
+
+RUN  apt-get update \
+  && apt-get install -y wget python3.10 bedtools python3-pip \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install --upgrade pip
+
+# creating a folder for ldsc
+RUN mkdir ldsc
+
+COPY make_annot.py /app/ldsc/
+COPY munge_sumstats.py /app/ldsc/
+COPY ldsc.py /app/ldsc/
+COPY ./ldscore/ /app/ldsc/ldscore/
+
+# install all of the python dependencies
+COPY requirements.txt /app/
+
+RUN pip install -r requirements.txt
+
+
+

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - pip:
   - bitarray==2.6.0
   - nose==1.3.7
-  - pybedtools==0.9.0
+  - pybedtools==0.9.1
   - scipy==1.9.2
   - pandas==1.5.0
   - numpy==1.23.3

--- a/ldsc.py
+++ b/ldsc.py
@@ -599,7 +599,7 @@ if __name__ == '__main__':
         log.log(header)
         log.log('Beginning analysis at {T}'.format(T=time.ctime()))
         start_time = time.time()
-        print(args.ref_ld)
+
         if args.n_blocks <= 1:
             raise ValueError('--n-blocks must be an integer > 1.')
         if args.bfile is not None:

--- a/ldsc.py
+++ b/ldsc.py
@@ -27,7 +27,7 @@ try:
 except AttributeError:
     raise ImportError('LDSC requires pandas version >= 0.17.0')
 
-__version__ = '2.0.0'
+__version__ = '2.0.2'
 MASTHEAD = "*********************************************************************\n"
 MASTHEAD += "* LD Score Regression (LDSC)\n"
 MASTHEAD += "* Version {V}\n".format(V=__version__)

--- a/ldsc.py
+++ b/ldsc.py
@@ -599,6 +599,7 @@ if __name__ == '__main__':
         log.log(header)
         log.log('Beginning analysis at {T}'.format(T=time.ctime()))
         start_time = time.time()
+        print(args.ref_ld)
         if args.n_blocks <= 1:
             raise ValueError('--n-blocks must be an integer > 1.')
         if args.bfile is not None:

--- a/ldscore/parse.py
+++ b/ldscore/parse.py
@@ -18,7 +18,7 @@ def series_eq(x, y):
 
 
 def read_csv(fh, **kwargs):
-    return pd.read_csv(fh, delim_whitespace=True, na_values='.', **kwargs)
+    return pd.read_csv(fh, sep='\s+', na_values='.', **kwargs)
 
 
 def sub_chr(s, chrom):
@@ -98,6 +98,7 @@ def sumstats(fh, alleles=False, dropna=True):
 
 def ldscore_fromlist(flist, num=None):
     '''Sideways concatenation of a list of LD Score files.'''
+
     ldscore_array = []
     for i, fh in enumerate(flist):
         y = ldscore(fh, num)

--- a/ldscore/sumstats.py
+++ b/ldscore/sumstats.py
@@ -142,14 +142,18 @@ def _read_w_ld(args, log):
 
 def _read_chr_split_files(chr_arg, not_chr_arg, log, noun, parsefunc, **kwargs):
     '''Read files split across 22 chromosomes (annot, ref_ld, w_ld).'''
+
     try:
         if not_chr_arg:
             log.log('Reading {N} from {F} ... ({p})'.format(N=noun, F=not_chr_arg, p=parsefunc.__name__))
             out = parsefunc(_splitp(not_chr_arg), **kwargs)
         elif chr_arg:
+
             f = ps.sub_chr(chr_arg, '[1-22]')
             log.log('Reading {N} from {F} ... ({p})'.format(N=noun, F=f, p=parsefunc.__name__))
+
             out = parsefunc(_splitp(chr_arg), _N_CHR, **kwargs)
+
     except ValueError as e:
         log.log('Error parsing {N}.'.format(N=noun))
         raise e
@@ -458,7 +462,7 @@ def _get_rg_table(rg_paths, RG, args):
     if args.samp_prev is not None and \
             args.pop_prev is not None and \
             all((i is not None for i in args.samp_prev)) and \
-            all((i is not None for it in args.pop_prev)):
+            all((it is not None for it in args.pop_prev)):
 
         c = list(map(lambda x, y: reg.h2_obs_to_liab(1, x, y), args.samp_prev[1:], args.pop_prev[1:]))
         x['h2_liab'] = list(map(lambda x, y: x * y, c, list(map(t('tot'), list(map(t('hsq2'), RG))))))

--- a/munge_sumstats.py
+++ b/munge_sumstats.py
@@ -441,7 +441,7 @@ def allele_merge(dat, alleles, log):
     a1234 = dat.A1[ii] + dat.A2[ii] + dat.MA[ii]
     match = a1234.apply(lambda y: y in sumstats.MATCH_ALLELES)
     jj = pd.Series(np.zeros(len(dat), dtype=bool))
-    jj[ii] = match
+    jj.loc[ii] = match # updated this to a modern pandas syntax to get rid of an error about incompatible dtypes
     old = ii.sum()
     n_mismatch = (~match).sum()
     if n_mismatch < old:
@@ -668,7 +668,7 @@ def munge_sumstats(args, p=True):
                 'Reading list of SNPs for allele merge from {F}'.format(F=args.merge_alleles))
             compression = get_compression(args.merge_alleles)
             merge_alleles = pd.read_csv(args.merge_alleles, compression=compression, header=0,
-                                        delim_whitespace=True, na_values='.')
+                                        sep='\s+', na_values='.')
             if any(x not in merge_alleles.columns for x in ["SNP", "A1", "A2"]):
                 raise ValueError(
                     '--merge-alleles must have columns SNP, A1, A2.')
@@ -687,7 +687,7 @@ def munge_sumstats(args, p=True):
         # figure out which columns are going to involve sign information, so we can ensure
         # they're read as floats
         signed_sumstat_cols = [k for k,v in list(cname_translation.items()) if v=='SIGNED_SUMSTAT']
-        dat_gen = pd.read_csv(args.sumstats, delim_whitespace=True, header=0,
+        dat_gen = pd.read_csv(args.sumstats, sep='\s+', header=0,
                 compression=compression, usecols=list(cname_translation.keys()),
                 na_values=['.', 'NA'], iterator=True, chunksize=args.chunksize,
                 dtype={c:np.float64 for c in signed_sumstat_cols})

--- a/munge_sumstats.py
+++ b/munge_sumstats.py
@@ -441,7 +441,7 @@ def allele_merge(dat, alleles, log):
     a1234 = dat.A1[ii] + dat.A2[ii] + dat.MA[ii]
     match = a1234.apply(lambda y: y in sumstats.MATCH_ALLELES)
     jj = pd.Series(np.zeros(len(dat), dtype=bool))
-    jj.loc[ii] = match # updated this to a modern pandas syntax to get rid of an error about incompatible dtypes
+    jj.loc[ii] = match 
     old = ii.sum()
     n_mismatch = (~match).sum()
     if n_mismatch < old:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bitarray==2.6.0
 nose==1.3.7
 numpy==1.23.3
 pandas==1.5.0
-pybedtools==0.9.0
+pybedtools==0.9.1
 pysam==0.19.1
 python-dateutil==2.8.2
 pytz==2022.4

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 setup(name='ldsc',
-      version='2.0.1',
+      version='2.0.2',
       description='LD Score Regression (LDSC)',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,15 @@ setup(name='ldsc',
       packages=['ldscore'],
       scripts=['ldsc.py', 'munge_sumstats.py', 'make_annot.py'],
       install_requires = [
-            'bitarray>=2.6.0',
-            'nose>=1.3.7', # this is only a test dep
-            'pybedtools>=0.9.0',
-            'scipy>=1.9.2',
-            'numpy>=1.23.3',
-            'pandas>=1.5.0'
+            'bitarray==2.6.0',
+            'nose==1.3.7',
+            'numpy==1.23.3',
+            'pandas==1.5.0',
+            'pybedtools==0.9.1',
+            'pysam==0.19.1',
+            'python-dateutil==2.8.2',
+            'pytz==2022.4',
+            'scipy==1.9.2',
+            'six==1.16.0'
       ]
 )


### PR DESCRIPTION
**Fixing an mistake accidentally introduced in the python 2to3 conversion:**
---
_summary:_ Python3 treats byte objects different than str and this was causing a bug in the line 144 list comprehension of 
munge_sumstats.py

_full explanation of problem:_
There was an error being produced on line 128 of munge_sumstats.py in the list comprehension "return [x.rstrip('\n') for x in opened_file.readline().split()]". This bug was seemingly introduced by the 2to3 conversion. ldsc 1.0.0 call the "openfun" function which returned a callable function based on the provided file compression. When the user provided a gzip file it would follow the if branch that uses gzip.open. The list compreshension on line 144 would then use this callable and call readlines on the resulting filehandle. In python 2.7, readlines returned a byte object which is just an alias to the str type (according to this answer on stackoverflow: [stackoverflow answer](https://stackoverflow.com/questions/5901706/the-bytes-type-in-python-2-7-and-pep-358)). In python 3, byte is a class different from str. This change in byte was causing the x.rstrip in the list comprehension to fail. 

_solution:_
I split the get_compression into two functions: get_compression and open_file. get_compression returns the appropriate compression type for the provided file. This function was not originally used in the above bug but was used later in the code. The open_file function actually opened the file and returned the filehandle. This allowed me to modify gzip.open to "gzip.open(_filehandle_, "rt")" which makes sure that the later call to readlines returns a str object.

**Removing pandas deprecation errors:**
---
_summary:_ There were several errors from pandas from deprecated named arguments and old syntax

_full explanation of problem:_
Newer versions of pandas gave a deprecation error when the delim_whitespace argument was passed to pd.read_csv. There was also an incompatible dtypes error on line 444 of munge_stats.py. This error was cause by the code changing the values of certain indices in a pandas series using an old syntax. 

_solution:_
I changed the named argument from delim_whitespace to 'sep="\t"' as pandas suggested in all the read_csv functions. I also changed the syntax at line 444 of munge_stats.py to a new syntax using loc which suppressed the previous deprecation error.

**Adding dockerfile:**
---
_summary:_ I made a very basic dockerfile that builds from the ubuntu 22.04 image.

_full explanation of what was done:_
People have reported that the make_annot.py script in ldsc fails when ldsc is pip installed because the package pybedtools does not automatically install bedtools. This causes the package pybedtools to not be able to find its dependency bedtools and therefore the make_annot.py script fails. 

_solution:_
I created a very basic docker file that builds off of ubuntu 22.04. This file install bedtools and python3.10 and then install all the python dependencies and copies ldsc. It currently runs on my mac and I build it for both the arm64 and amd64 architectures so it should work on linux servers. I have not been able to test this yet but I hope to soon

**Things left:**
---
There is still an warning left in the code indicating that in future versions of pandas (>=3.0) that pyarrow will be required. I did not feel the need to fix this because pyarrow is not currently used in the code.