### PR TITLE
Fix bugs in partitioned heritability and cell type specific analysis related functions

### DIFF
--- a/src/ldsc/annotate/make_annot.py
+++ b/src/ldsc/annotate/make_annot.py
@@ -59,4 +59,4 @@ def make_annot_files(args) -> None:
     df_annot.fillna(0, inplace=True)
     df_annot = df_annot[["ANNOT"]].astype(int)
 
-    df_annot.to_csv(args.annot, sep="\t", index=False, compression="infer")
+    df_annot.to_csv(args.annot_file, sep="\t", index=False, compression="infer")

--- a/src/ldsc/ldscore/ldscore.py
+++ b/src/ldsc/ldscore/ldscore.py
@@ -732,7 +732,7 @@ def ldscore(args):
         ldscore_colnames = [y + col_prefix + scale_suffix for y in annot_colnames]
 
     # print .ldscore. Output columns: CHR, BP, RS, [LD Scores]
-    out_fname = args.out.name + "." + file_suffix + ".ldscore"
+    out_fname = str(args.out) + "." + file_suffix + ".ldscore"
     new_colnames = geno_array.colnames + ldscore_colnames
     df = pd.DataFrame.from_records(np.c_[geno_array.df, lN])
     df.columns = new_colnames
@@ -763,12 +763,12 @@ def ldscore(args):
     l2_suffix = ".gz"
     logger.info(f"Writing LD Scores for {len(df)} SNPs to {out_fname}.gz")
     df.drop(["CM", "MAF"], axis=1).to_csv(
-        out_fname,
+        f"{out_fname}.gz",
         sep="\t",
         header=True,
         index=False,
         float_format="%.3f",
-        compression="gzip",
+        compression="gzip"
     )
     if annot_matrix is not None:
         M = np.atleast_1d(np.squeeze(np.asarray(np.sum(annot_matrix, axis=0))))

--- a/src/ldsc/ldscore/ldscore.py
+++ b/src/ldsc/ldscore/ldscore.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from itertools import product
 import logging
 import numpy as np
@@ -286,6 +287,7 @@ class PlinkBEDFile(__GenotypeArrayInMemory__):
         )
 
     def __read__(self, fname, m, n):
+        fname = Path(fname)
         if fname.suffix != ".bed":
             raise ValueError(".bed filename must end in .bed")
 

--- a/src/ldsc/ldscore/ldscore.py
+++ b/src/ldsc/ldscore/ldscore.py
@@ -752,7 +752,7 @@ def ldscore(args):
         )
 
         print_snps.columns = ["SNP"]
-        df = df.iloc[df.SNP.isin(print_snps.SNP), :]
+        df = df.loc[df.SNP.isin(print_snps.SNP), :]
         if len(df) == 0:
             raise ValueError("After merging with --print-snps, no SNPs remain.")
         else:

--- a/src/ldsc/ldscore/ldscore.py
+++ b/src/ldsc/ldscore/ldscore.py
@@ -781,14 +781,12 @@ def ldscore(args):
         M_5_50 = [np.sum(geno_array.maf > 0.05)]
 
     # print .M
-    fout_M = open(args.out + "." + file_suffix + ".M", "wb")
-    print("\t".join(map(str, M)), file=fout_M)
-    fout_M.close()
+    with open(f"{args.out}.{file_suffix}.M", "wb") as fout_M:
+        fout_M.write("\t".join(map(str, M)).encode() + b'\n')
 
     # print .M_5_50
-    fout_M_5_50 = open(args.out + "." + file_suffix + ".M_5_50", "wb")
-    print("\t".join(map(str, M_5_50)), file=fout_M_5_50)
-    fout_M_5_50.close()
+    with open(f"{args.out}.{file_suffix}.M_5_50", "wb") as fout_M_5_50:
+        fout_M_5_50.write("\t".join(map(str, M_5_50)).encode() + b'\n')
 
     # print annot matrix
     if (args.cts_bin is not None) and not args.no_print_annot:

--- a/src/ldsc/ldscore/ldscore.py
+++ b/src/ldsc/ldscore/ldscore.py
@@ -668,7 +668,7 @@ def ldscore(args):
         keep_indivs = None
 
     # read genotype array
-    logger.info("Reading genotypes from {array_file}")
+    logger.info(f"Reading genotypes from {array_file}")
     geno_array = array_obj(
         array_file,
         n,

--- a/src/ldsc/ldscore/parse.py
+++ b/src/ldsc/ldscore/parse.py
@@ -233,9 +233,10 @@ def annot(fh_list, num=None, frqfile=None):
             if frqfile is not None:
                 df_annot_chr_list = [
                     annot_parser(
-                        sub_chr(fh, f"{chrom}{annot_suffix[i]}{annot_compression[i]}"),
+                        sub_chr(fh, f"{chrom}{annot_suffix[i]}"),
+                        annot_compression[i],
                         sub_chr(frqfile, f"{chrom}{frq_suffix}"),
-                        frq_compression,
+                        frq_compression
                     )
                     for i, fh in enumerate(fh_list)
                 ]

--- a/src/ldsc/ldscore/parse.py
+++ b/src/ldsc/ldscore/parse.py
@@ -310,6 +310,7 @@ def __ID_List_Factory__(colnames, keepcol, fname_end, header=None, usecols=None)
             self.n = len(self.df)
 
         def __read__(self, fname):
+            fname = Path(fname)
             end = self.__fname_end__
             if end and fname.suffix != end:
                 raise ValueError("{f} filename must end in {f}".format(f=end))

--- a/src/ldsc/ldscore/parse.py
+++ b/src/ldsc/ldscore/parse.py
@@ -22,7 +22,7 @@ def read_csv(fh, **kwargs):
 
 def sub_chr(filepath: Path, suffix: str) -> Path:
     """Substitute chr for @, else append chr to the end of str."""
-
+    filepath = Path(filepath)
     if filepath.is_dir():
         return filepath / f"{suffix}"
     else:

--- a/src/ldsc/ldscore/sumstats.py
+++ b/src/ldsc/ldscore/sumstats.py
@@ -466,7 +466,7 @@ def estimate_h2(args) -> reg.Hsq:
         df_results = hsqhat._overlap_output(
             ref_ld_cnames, overlap_matrix, M_annot, M_tot, args.print_coefficients
         )
-        df_results.to_csv(args.out + ".results", sep="\t", index=False)
+        df_results.to_csv(str(args.out) + ".results", sep="\t", index=False)
         logger.info(f"Results printed to {args.out}.results")
 
     return hsqhat

--- a/src/ldsc/ldscore/sumstats.py
+++ b/src/ldsc/ldscore/sumstats.py
@@ -379,7 +379,7 @@ def cell_type_specific(args):
 
     df_results = pd.DataFrame(data=results_data, columns=results_columns)
     df_results.sort_values(by="Coefficient_P_value", inplace=True)
-    df_results.to_csv(args.out + ".cell_type_results.txt", sep="\t", index=False)
+    df_results.to_csv(str(args.out) + ".cell_type_results.txt", sep="\t", index=False)
     logger.info(f"Results printed to {args.out}.cell_type_results.tx")
 
 


### PR DESCRIPTION
**CODE**

```{bash}
ldsc make_annot \
--bed-file /mnt/bedfiles/E096-H3K27ac.bed \
--bimfile  /mnt/plink_files/1000G.EUR.hg38.15.bim \
--annot-file /mnt/LDannot/E096-H3K27ac.15.annot.gz \
--log-filename /mnt/LDannot/E096-H3K27ac.log
```

**ERROR**

```{bash}
File "/app/ldsc/src/ldsc/annotate/make_annot.py", line 62, in make_annot_files
    df_annot.to_csv(args.annot, sep="\t", index=False, compression="infer")
AttributeError: 'Namespace' object has no attribute 'annot'
```

**CAUSE**

> Line 62 - ../src/ldsc/annotate/make_annot.py

The `argparse` is parsing the command line argument `--annot-file` as `annot_file` which is incorrectly specified in line 62 of the code

```{bash}
# Line 62
df_annot.to_csv(args.annot, sep="\t", index=False, compression="infer")
```

**SOLUTION**

In line 62, change `args.annot` with `args.annot_file`

```{bash}
df_annot.to_csv(args.annot_file, sep="\t", index=False, compression="infer")
```
